### PR TITLE
updating extract2fsf to address several formatting issues when the fsf_client scan_cmd is formatted and executed

### DIFF
--- a/frameworks/files/extract2fsf.bro
+++ b/frameworks/files/extract2fsf.bro
@@ -8,7 +8,7 @@ event file_state_remove(f: fa_file)
                # invoke the FSF-CLIENT and add the source metadata of ROCK01 (sensorID), we're suppressing the returned report
                # becuase we don't need that
                local script_path = cat(@DIR, "/fsf-client/fsf_client.py");
-               local scan_cmd = fmt("%s --suppress-report --archive none --source %s %s/%s", script_path, ROCK::sensor_id, FileExtract::prefix, f$info$extracted);
+	       local scan_cmd = fmt("python %s --suppress-report --archive none --source %s %s%s", script_path, ROCK::sensor_id, FileExtract::prefix, f$info$extracted);
                system(scan_cmd);
          }
 }


### PR DESCRIPTION
updating the scan_cmd to also include the python keyword--this address edge cases where the shell wasn't properly handing the file to python for execution. Also removing an unnecessary string formatting character on the file path for the file to submit.