### PR TITLE
Re-license scripts and update to latest compatibilities

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,27 +1,201 @@
-Copyright (C) 2016, Missouri Cyber Team
-All rights reserved.
+                            Apache License
+                      Version 2.0, January 2004
+                  http://www.apache.org/licenses/
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Definitions.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+"License" shall mean the terms and conditions for use, reproduction,
+and distribution as defined by Sections 1 through 9 of this document.
 
-* Neither the name of Missouri Cyber Team nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+"Licensor" shall mean the copyright owner or entity authorized by
+the copyright owner that is granting the License.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"Legal Entity" shall mean the union of the acting entity and all
+other entities that control, are controlled by, or are under common
+control with that entity. For the purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or
+otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity
+exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation
+source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical
+transformation or translation of a Source form, including but
+not limited to compiled object code, generated documentation,
+and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or
+Object form, made available under the License, as indicated by a
+copyright notice that is included in or attached to the work
+(an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object
+form, that is based on (or derived from) the Work and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship. For the purposes
+of this License, Derivative Works shall not include works that remain
+separable from, or merely link (or bind by name) to the interfaces of,
+the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including
+the original version of the Work and any modifications or additions
+to that Work or Derivative Works thereof, that is intentionally
+submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of
+the copyright owner. For the purposes of this definition, "submitted"
+means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems,
+and issue tracking systems that are managed by, or on behalf of, the
+Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity
+on behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the
+Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+this License, each Contributor hereby grants to You a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer the Work,
+where such license applies only to those patent claims licensable
+by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work
+or a Contribution incorporated within the Work constitutes direct
+or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate
+as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+Work or Derivative Works thereof in any medium, with or without
+modifications, and in Source or Object form, provided that You
+meet the following conditions:
+
+(a) You must give any other recipients of the Work or
+Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices
+stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works
+that You distribute, all copyright, patent, trademark, and
+attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of
+the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its
+distribution, then any Derivative Works that You distribute must
+include a readable copy of the attribution notices contained
+within such NOTICE file, excluding those notices that do not
+pertain to any part of the Derivative Works, in at least one
+of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or,
+within a display generated by the Derivative Works, if and
+wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and
+do not modify the License. You may add Your own attribution
+notices within Derivative Works that You distribute, alongside
+or as an addendum to the NOTICE text from the Work, provided
+that such additional attribution notices cannot be construed
+as modifying the License.
+
+You may add Your own copyright statement to Your modifications and
+may provide additional or different license terms and conditions
+for use, reproduction, or distribution of Your modifications, or
+for any such Derivative Works as a whole, provided Your use,
+reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+any Contribution intentionally submitted for inclusion in the Work
+by You to the Licensor shall be under the terms and conditions of
+this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify
+the terms of any separate license agreement you may have executed
+with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+names, trademarks, service marks, or product names of the Licensor,
+except as required for reasonable and customary use in describing the
+origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+agreed to in writing, Licensor provides the Work (and each
+Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied, including, without limitation, any warranties or conditions
+of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any
+risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+whether in tort (including negligence), contract, or otherwise,
+unless required by applicable law (such as deliberate and grossly
+negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or out of the use or inability to use the
+Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses), even if such Contributor
+has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer,
+and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason
+of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following
+boilerplate notice, with the fields enclosed by brackets "[]"
+replaced with your own identifying information. (Don't include
+the brackets!)  The text should be enclosed in the appropriate
+comment syntax for the file format. We also recommend that a
+file or class name and description of purpose be included on the
+same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/__load__.bro
+++ b/__load__.bro
@@ -1,8 +1,15 @@
-# Copyright (C) 2016, Missouri Cyber Team
-# All Rights Reserved
-# See the file "LICENSE" in the main distribution directory for details
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 @load ./rock
-
-
-

--- a/frameworks/files/extract2fsf.bro
+++ b/frameworks/files/extract2fsf.bro
@@ -1,6 +1,19 @@
-# knifehands
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # take extracted files and submit to FSF
- 
+
 event file_state_remove(f: fa_file)
     {
         if ( f$info?$extracted )

--- a/frameworks/logging/disable-ascii.bro
+++ b/frameworks/logging/disable-ascii.bro
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2018 RockNSM
+# Copyright (C) 2018 RockNSM
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,26 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-module Kafka;
 
-redef Kafka::topic_name = "bro-raw";
-redef Kafka::json_timestamps = JSON::TS_ISO8601;
-redef Kafka::tag_json = F;
-
-# Enable bro logging to kafka for all logs
+# Disable bro logging to filesystem for all logs
 event bro_init() &priority=-5
 {
     for (stream_id in Log::active_streams)
     {
-        if (|Kafka::logs_to_send| == 0 || stream_id in Kafka::logs_to_send)
-        {
-            local filter: Log::Filter = [
-                $name = fmt("kafka-%s", stream_id),
-                $writer = Log::WRITER_KAFKAWRITER,
-                $config = table(["stream_id"] = fmt("%s", stream_id))
-            ];
-
-            Log::add_filter(stream_id, filter);
-        }
+        Log::remove_filter(stream_id, "default");
     }
 }

--- a/frameworks/logging/extension.bro
+++ b/frameworks/logging/extension.bro
@@ -1,3 +1,16 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ## Setup event extension to include sensor and probe name
 type Extension: record {

--- a/frameworks/notice/scot-integration.bro
+++ b/frameworks/notice/scot-integration.bro
@@ -1,6 +1,16 @@
-# Copyright (C) 2016, Missouri Cyber Team
-# All Rights Reserved
-# See the file "LICENSE" in the main distribution directory for details
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ##! Hooks to forward notices to [SCOT](https://github.com/sandialabs/scot)
 # This will forward all notices by default. Add notice types to

--- a/misc/conn-add-geoip.bro
+++ b/misc/conn-add-geoip.bro
@@ -1,6 +1,16 @@
-# Copyright (C) 2016, Missouri Cyber Team
-# All Rights Reserved
-# See the file "LICENSE" in the main distribution directory for details
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ##! Add geo_location for the originator and responder of a connection
 ##! to the connection logs.

--- a/misc/conn-add-worker.bro
+++ b/misc/conn-add-worker.bro
@@ -1,3 +1,16 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 redef record Conn::Info += {
         peer_descr: string &default="unknown" &log;
 };

--- a/plugins/afpacket.bro
+++ b/plugins/afpacket.bro
@@ -1,3 +1,17 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Workaround for AF_Packet plugin across multiple interfaces
 # See https://bro-tracker.atlassian.net/browse/BIT-1747 for more info
 @load scripts/rock/plugins/afpacket

--- a/protocols/dns/known_domains.bro
+++ b/protocols/dns/known_domains.bro
@@ -1,11 +1,21 @@
-# Copyright (C) 2016, Missouri Cyber Team
-# All Rights Reserved
-# See the file "LICENSE" in the main distribution directory for details
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # NOTE: On a busy network, this may consume a lot of memory. Revisit
 # when Broker is efficient enough to handle this.
 
-module MOCYBER;
+module RockNSM;
 
 export {
 ## The known-hosts logging stream identifier.
@@ -34,10 +44,10 @@ export {
 
 event bro_init()
 {
-  Log::create_stream(MOCYBER::UNIQDNS_LOG, [$columns=Info, $ev=log_known_domains, $path="known_domains"]);
-  local f = Log::get_filter(MOCYBER::UNIQDNS_LOG, "default");
+  Log::create_stream(RockNSM::UNIQDNS_LOG, [$columns=Info, $ev=log_known_domains, $path="known_domains"]);
+  local f = Log::get_filter(RockNSM::UNIQDNS_LOG, "default");
   #f$interv = 15 min;
-  Log::add_filter(CyberDev::UNIQDNS_LOG, f);
+  Log::add_filter(RockNSM::UNIQDNS_LOG, f);
 }
 
 event dns_query_reply(c: connection, msg: dns_msg, query: string, qtype: count, qclass: count)
@@ -47,6 +57,6 @@ event dns_query_reply(c: connection, msg: dns_msg, query: string, qtype: count, 
   if(query !in known_domains)
   {
     add known_domains[query];
-    Log::write( MOCYBER::UNIQDNS_LOG,[$ts=network_time(),$domain=query] );
+    Log::write( RockNSM::UNIQDNS_LOG,[$ts=network_time(),$domain=query] );
   }
 }

--- a/protocols/http/cookie-log.bro
+++ b/protocols/http/cookie-log.bro
@@ -1,3 +1,16 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 module Cookie;
 
 export {

--- a/protocols/http/http-body-url-extraction.bro
+++ b/protocols/http/http-body-url-extraction.bro
@@ -1,3 +1,17 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This scans the body of HTTP-served html documents for urls that may be
 # loaded in the intel database
 #

--- a/protocols/pop3/__load__.bro
+++ b/protocols/pop3/__load__.bro
@@ -1,1 +1,14 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 @load ./main.bro

--- a/protocols/pop3/main.bro
+++ b/protocols/pop3/main.bro
@@ -1,3 +1,17 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ##! Basic POP3 analyzer
 # From here: https://github.com/albert-magyar/bro/blob/topic/pop3/scripts/base/protocols/pop3/main.bro
 

--- a/protocols/smtp/extract_smtp_body.bro
+++ b/protocols/smtp/extract_smtp_body.bro
@@ -1,7 +1,16 @@
-# Copyright (C) 2016, Missouri Cyber Team
-# All Rights Reserved
-# See the file "LICENSE" in the main distribution directory for details
-
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # This policy extracts all SMTP bodies (from client side) seen in traffic.
 
 # NOTE: On a heavy SMTP segment, this will generate a lot of files!

--- a/protocols/smtp/smtp-url.bro
+++ b/protocols/smtp/smtp-url.bro
@@ -1,0 +1,175 @@
+##! A script for handling URLs in SMTP traffic.  This script does
+##! two things.  It logs URLs discovered in SMTP traffic.  It
+##! also records them in a bloomfilter and looks for them to be
+##! visited through HTTP requests.
+##!
+##! Authors: Aashish Sharma <asharma@lbl.gov>
+##!          Seth Hall <seth@icir.org>
+##!          Derek Ditch <derek@rocknsm.io>
+
+
+@load base/utils/urls
+
+module SMTP_URL;
+
+export {
+        redef enum Log::ID += { Links_LOG };
+
+        type Info: record {
+                ## When the email was seen.
+                ts:   time    &log;
+                ## Unique ID for the connection.
+                uid:  string  &log;
+                ## Connection details.
+                id:   conn_id &log;
+                ## Depth of the email into the SMTP exchange.
+                trans_depth: count &log;
+                ## The host field extracted from the discovered URL.
+                host: string  &log &optional;
+                ## URL that was discovered.
+                url:  string  &log &optional;
+        };
+
+        redef enum Notice::Type += {
+                ## A link discovered in an email appears to have been clicked.
+                Link_in_Email_Clicked,
+
+                ## An email was seen in email that matched the pattern in
+                ## `SMTP_URL::suspicious_urls`
+                Suspicious_URL,
+
+                ## Certain file extensions in email links can be watched for
+                ## with the pattern in `SMTP_URL::suspicious_file_extensions`
+                Suspicious_File_Extension,
+
+                ## URL with a dotted IP address seen in an email.
+                Dotted_URL
+        };
+
+        const suspicious_file_extensions = /\.([rR][aA][rR]|[eE][xX][eE]|[zZ][iI][pP])$/ &redef;
+        const suspicious_urls = /googledocs?/ &redef;
+
+        const ignore_file_types = /\.([gG][iI][fF]|[pP][nN][gG]|[jJ][pP][gG]|[xX][mM][lL]|[jJ][pP][eE]?[gG]|[cC][sS][sS])$/ &redef;
+
+        ## The following
+        const ignore_mail_originators: set[subnet] = { } &redef;
+        const ignore_mailfroms = /bro@|alerts|reports/ &redef;
+        const ignore_notification_emails = {"alerts@example.com", "notices@example.com"} &redef;
+        const ignore_site_links = /http:\/\/.*\.example\.com\/|http:\/\/.*\.example\.net/ &redef;
+}
+
+# The bloomfilter that stores all of the links seen in email.
+global mail_links_bf: opaque of bloomfilter;
+
+redef record connection += {
+        smtp_url: Info &optional;
+};
+
+event bro_init() &priority=5
+        {
+        # initialize the bloomfilter
+        mail_links_bf = bloomfilter_basic_init(0.00000001, 10000000, "SMTP_URL");
+
+        Log::create_stream(Links_LOG, [$columns=Info]);
+        }
+
+function extract_host(name: string): string
+        {
+        local split_on_slash = split_string(name, /\//);
+        return split_on_slash[3];
+        }
+
+function log_smtp_urls(c: connection, url: string)
+        {
+        c$smtp_url = Info($ts   = c$smtp$ts,
+                          $uid  = c$uid,
+                          $id   = c$id,
+                          $trans_depth = c$smtp$trans_depth,
+                          $host = extract_host(url),
+                          $url  = url);
+
+        Log::write(SMTP_URL::Links_LOG, c$smtp_url);
+        }
+
+event SMTP_URL::email_data(f: fa_file, data: string)
+        {
+        # Grab the connection.
+        local c: connection;
+        for ( cid in f$conns )
+                {
+                c = f$conns[cid];
+                break;
+                }
+
+        if( c$smtp?$mailfrom && ignore_mailfroms in c$smtp$mailfrom )
+                {
+                return;
+                }
+
+        if ( c$smtp?$to )
+                {
+                for ( to in c$smtp$to )
+                        {
+                        if ( to in ignore_notification_emails )
+                                return;
+                        }
+                }
+
+        local mail_info = Files::describe(f);
+        local urls = find_all_urls(data);
+        for ( link in urls )
+                {
+                if ( ignore_file_types !in link )
+                        {
+                        bloomfilter_add(mail_links_bf, link);
+                        log_smtp_urls(c, link);
+
+                        if ( suspicious_file_extensions in link )
+                                {
+                                NOTICE([$note = Suspicious_File_Extension,
+                                        $msg  = fmt("Suspicious file extension embedded in URL %s from  %s", link, c$id$orig_h),
+                                        $sub  = mail_info,
+                                        $conn = c]);
+                                }
+
+                        if ( suspicious_urls in link )
+                                {
+                                NOTICE([$note = Suspicious_URL,
+                                        $msg  = fmt("Suspicious text embedded in URL %s from  %s", link, c$smtp$uid),
+                                        $sub  = mail_info,
+                                        $conn = c]);
+                                }
+
+                        if ( /([[:digit:]]{1,3}\.){3}[[:digit:]]{1,3}.*/ in link )
+                                {
+                                NOTICE([$note = Dotted_URL,
+                                        $msg  = fmt("Embedded IP address in URL %s from  %s", link, c$id$orig_h),
+                                        $sub  = mail_info,
+                                        $conn = c]);
+                                }
+
+                }
+        }
+}
+
+event file_over_new_connection(f: fa_file, c: connection, is_orig: bool)
+        {
+        if ( f$source == "SMTP" && c?$smtp &&
+             c$id$orig_h !in ignore_mail_originators )
+                {
+                Files::add_analyzer(f, Files::ANALYZER_DATA_EVENT, [$stream_event=SMTP_URL::email_data]);
+                }
+        }
+
+event http_message_done(c: connection, is_orig: bool, stat: http_message_stat) &priority=-3
+        {
+        local str = HTTP::build_url_http(c$http);
+        if ( bloomfilter_lookup(SMTP_URL::mail_links_bf, str) > 0 &&
+             ignore_file_types !in str &&
+             ignore_site_links !in str)
+                {
+                NOTICE([$note=SMTP_URL::Link_in_Email_Clicked,
+                        $msg=fmt("URL %s ", str),
+                        $conn=c]);
+                }
+        }

--- a/protocols/smtp/smtp-url.bro
+++ b/protocols/smtp/smtp-url.bro
@@ -1,3 +1,17 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ##! A script for handling URLs in SMTP traffic.  This script does
 ##! two things.  It logs URLs discovered in SMTP traffic.  It
 ##! also records them in a bloomfilter and looks for them to be

--- a/protocols/ssl/new-certs.bro
+++ b/protocols/ssl/new-certs.bro
@@ -1,3 +1,17 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ##! Generate notices when X.509 certificates over SSL/TLS are expired or
 ##! going to expire soon based on the date and time values stored within the
 ##! certificate.

--- a/rock.bro
+++ b/rock.bro
@@ -1,15 +1,36 @@
-# Copyright (C) 2016, Missouri Cyber Team
-# All Rights Reserved
-# See the file "LICENSE" in the main distribution directory for details
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 module ROCK;
 
 export {
-  const sensor_id = "sensor001-001" &redef;
+  const sensor_id = gethostname() &redef;
 }
 
-# Load integration with Snort on ROCK
-@load ./frameworks/files/unified2-integration
+
+#=== Bro built-ins ===================================
+
+# Collect on SMB protocol
+@load policy/protocols/smb
+
+# Enable VLAN Logging
+@load policy/protocols/conn/vlan-logging
+
+# Log MAC addresses
+@load policy/protocols/conn/mac-logging
+
+#== ROCK specific scripts ============================
 
 # Load integration with FSF
 @load ./frameworks/files/extract2fsf
@@ -19,8 +40,10 @@ export {
 redef FileExtract::prefix = "/data/bro/logs/extract_files/";
 redef FileExtract::default_limit = 1048576000;
 
-# Add GeoIP info to conn log
-@load ./misc/conn-add-geoip
-
 # Add sensor and log meta information to each log
 @load ./frameworks/logging/extension
+
+### Sensor specific scripts ######################
+
+# Configure AF_PACKET, if in use
+@load ./plugins/afpacket

--- a/skeleton.bro
+++ b/skeleton.bro
@@ -1,6 +1,16 @@
-# Copyright (C) 2016, Missouri Cyber Team
-# All Rights Reserved
-# See the file "LICENSE" in the main distribution directory for details
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 ##! Short description of what this file is about
 #  This file provides a rough sketch of a bro script

--- a/utils/json.bro
+++ b/utils/json.bro
@@ -1,3 +1,17 @@
+# Copyright (C) 2016-2018 RockNSM
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @load base/utils/strings
 
 module JSON;


### PR DESCRIPTION
* Re-license everything under APL 2.0
* Disables GeoIP in conn logs by default
* Disables Unified2 by default
* Adds optional script to disable filesystem logging
* Fixes Kafka output script to be compatible with current upstream release
