### PR TITLE
Update rock.bro

### DIFF
--- a/rock.bro
+++ b/rock.bro
@@ -29,6 +29,9 @@ export {
 # Log MAC addresses
 @load policy/protocols/conn/mac-logging
 
+# Log (All) Client and Server HTTP Headers
+@load policy/protocols/http/header-names.bro
+
 #== ROCK specific scripts ============================
 # Add empty Intel framework database
 @load ./frameworks/intel


### PR DESCRIPTION
logging all http headers allows for a few things:
- domain fronting detection
- http evasion sort of things with double headers.
- greater visibility into potential software/programs
- additional indicator possibilites
- additional hunting possibilities looking for abnormal/rare headers